### PR TITLE
Fix bug preventing the Bottom Navigation bar to detect clicks

### DIFF
--- a/library/src/main/kotlin/dev/jahir/frames/ui/fragments/base/BaseFramesFragment.kt
+++ b/library/src/main/kotlin/dev/jahir/frames/ui/fragments/base/BaseFramesFragment.kt
@@ -30,11 +30,6 @@ abstract class BaseFramesFragment<T> : Fragment(R.layout.fragment_stateful_recyc
     private var swipeRefreshLayout: SwipeRefreshLayout? = null
     var recyclerView: StatefulRecyclerView? = null
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        setupContentBottomOffset()
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         recyclerView = view.findViewById(R.id.recycler_view)
@@ -70,9 +65,12 @@ abstract class BaseFramesFragment<T> : Fragment(R.layout.fragment_stateful_recyc
     }
 
     open fun setupContentBottomOffset(view: View? = null) {
-        (context as? BaseSystemUIVisibilityActivity<*>)?.bottomNavigation?.let {
-            it.post {
-                (view ?: getView())?.setPaddingBottom(it.measuredHeight)
+        (view ?: getView())?.let { v ->
+            v.post {
+                val bottomNavigationHeight =
+                    (context as? BaseSystemUIVisibilityActivity<*>)?.bottomNavigation?.measuredHeight
+                        ?: 0
+                v.setPaddingBottom(bottomNavigationHeight)
             }
         }
     }

--- a/library/src/main/kotlin/dev/jahir/frames/ui/fragments/base/BaseFramesFragment.kt
+++ b/library/src/main/kotlin/dev/jahir/frames/ui/fragments/base/BaseFramesFragment.kt
@@ -30,6 +30,11 @@ abstract class BaseFramesFragment<T> : Fragment(R.layout.fragment_stateful_recyc
     private var swipeRefreshLayout: SwipeRefreshLayout? = null
     var recyclerView: StatefulRecyclerView? = null
 
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        setupContentBottomOffset()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         recyclerView = view.findViewById(R.id.recycler_view)

--- a/library/src/main/kotlin/dev/jahir/frames/ui/fragments/base/BaseFramesFragment.kt
+++ b/library/src/main/kotlin/dev/jahir/frames/ui/fragments/base/BaseFramesFragment.kt
@@ -72,10 +72,10 @@ abstract class BaseFramesFragment<T> : Fragment(R.layout.fragment_stateful_recyc
     open fun setupContentBottomOffset(view: View? = null) {
         (view ?: getView())?.let { v ->
             v.post {
-                val bottomNavigationHeight =
-                    (context as? BaseSystemUIVisibilityActivity<*>)?.bottomNavigation?.measuredHeight
+                v.setPaddingBottom(
+                    (activity as? BaseSystemUIVisibilityActivity<*>)?.bottomNavigation?.measuredHeight
                         ?: 0
-                v.setPaddingBottom(bottomNavigationHeight)
+                )
             }
         }
     }


### PR DESCRIPTION
This commit removes `setupContentBottomOffset()` from `onAttach()` of BaseFramesFragment.kt because view and getView() are both null at this point. Additionally, we're getting the measured height of `bottomNavigation` only if one of the views on which the padding should be applied isn't null. This prevents the initialization of `bottomNavigation` too early.

Fix #174 

