### PR TITLE
Fix AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -98,7 +98,8 @@
 
         <activity
             android:name=".ui.activities.MuzeiSettingsActivity"
-            android:exported="true" />
+            android:exported="true"
+            tools:replace="android:exported" />
 
     </application>
 


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
<!--
Describe the changes you have made on a high level in the project.
If this PR is related to an issue, reference it here.
-->
There was an issue with Manifest Merge when using Blueprint. The issue was caused by Frames' AndroidManifest.xml. This PR (probably) fixes the issue.

Here is a screenshot of the issue
![studio64_uDaSgxpRr2](https://user-images.githubusercontent.com/44255990/95331160-32479c00-08c7-11eb-8b69-45f08de7b8e9.png)
